### PR TITLE
fix: resolve syntax issues in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -37,7 +37,5 @@
     "husky": "^4.3.0",
     "lint-staged": "^10.5.4",
     "prettier": "2.2.1"
-    "lint-staged": "^10.5.1",
-    "prettier": "2.2.1"
   }
 }


### PR DESCRIPTION
This action can't be used because the `package.json` is invalid. Looks like Dependabot has also filed an issue #38 as it isn't able to parse your `package.json`. Seems like an easy mistake to make 😅, this PR fixes it!